### PR TITLE
Serialise XML child elements in content-model order

### DIFF
--- a/common/src/main/java/com/regnosys/rosetta/common/serialisation/xml/RosettaXMLModule.java
+++ b/common/src/main/java/com/regnosys/rosetta/common/serialisation/xml/RosettaXMLModule.java
@@ -97,7 +97,7 @@ public class RosettaXMLModule extends SimpleModule {
     public void setupModule(SetupContext context) {
         // Note: order is important. Each modifier is inserted to the front of the list of modifiers.
         final SubstitutionMapLoader substitutionMapLoader = new SubstitutionMapLoader(classLoader);
-        context.addBeanSerializerModifier(new RosettaBeanSerializerModifier(substitutionMapLoader));
+        context.addBeanSerializerModifier(new RosettaBeanSerializerModifier(substitutionMapLoader, rosettaXMLConfiguration));
         context.addBeanSerializerModifier(new XmlBeanSerializerModifier());
         context.addBeanDeserializerModifier(new RosettaBeanDeserializerModifier(substitutionMapLoader, rosettaXMLConfiguration));
         context.addBeanDeserializerModifier(new XmlBeanDeserializerModifier(FromXmlParser.DEFAULT_UNNAMED_TEXT_PROPERTY));

--- a/common/src/main/java/com/regnosys/rosetta/common/serialisation/xml/deserialization/XMLContentModelDisambiguatingDeserializer.java
+++ b/common/src/main/java/com/regnosys/rosetta/common/serialisation/xml/deserialization/XMLContentModelDisambiguatingDeserializer.java
@@ -39,10 +39,16 @@ import com.regnosys.rosetta.common.serialisation.xml.deserialization.VirtualPath
 import com.regnosys.rosetta.common.serialisation.xml.deserialization.XMLContentModelMatcher.OccurrenceKey;
 import com.regnosys.rosetta.common.serialisation.xml.deserialization.XMLContentModelMatcher.RoutingResult;
 import com.rosetta.model.lib.RosettaModelObject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
 import java.util.HashSet;
+import java.util.IdentityHashMap;
+import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
@@ -65,6 +71,8 @@ final class XMLContentModelDisambiguatingDeserializer extends DelegatingDeserial
 
     private static final long serialVersionUID = 1L;
 
+    private static final Logger LOGGER = LoggerFactory.getLogger(XMLContentModelDisambiguatingDeserializer.class);
+
     private final Class<?> beanClass;
     private final TypeXMLConfiguration typeConfig;
     private final XMLContentModel contentModel;
@@ -72,6 +80,11 @@ final class XMLContentModelDisambiguatingDeserializer extends DelegatingDeserial
     private final boolean hasAnyNode;
     private final Set<String> attributeNames;
     private final VirtualPathBuilderHelper virtualPathBuilderHelper;
+    // Canonical document-order position of each element name (first occurrence in a DFS of the
+    // content model). Used to stably reorder misordered input before a lenient re-match.
+    private final Map<String, Integer> canonicalPosition;
+    // Element names that map to exactly one path, hence routable regardless of order.
+    private final Set<String> uniquelyRoutableNames;
 
     XMLContentModelDisambiguatingDeserializer(JsonDeserializer<?> delegatee,
                                               Class<?> beanClass,
@@ -86,6 +99,31 @@ final class XMLContentModelDisambiguatingDeserializer extends DelegatingDeserial
         this.hasAnyNode = containsAnyNode(contentModel);
         this.attributeNames = collectXmlAttributeNames(typeConfig);
         this.virtualPathBuilderHelper = virtualPathBuilderHelper;
+        this.canonicalPosition = new HashMap<>();
+        this.uniquelyRoutableNames = new HashSet<>();
+        indexElementNames(contentModel);
+    }
+
+    private void indexElementNames(XMLContentModel root) {
+        Map<String, Set<List<String>>> pathsByName = new HashMap<>();
+        int[] counter = {0};
+        walk(root, node -> {
+            if (node.getNodeType() != XMLContentModelNodeType.ELEMENT
+                    && node.getNodeType() != XMLContentModelNodeType.ANY) {
+                return;
+            }
+            node.getXmlName().ifPresent(name -> {
+                canonicalPosition.putIfAbsent(name, counter[0]);
+                node.getPath().ifPresent(path ->
+                        pathsByName.computeIfAbsent(name, k -> new HashSet<>()).add(path));
+            });
+            counter[0]++;
+        });
+        pathsByName.forEach((name, paths) -> {
+            if (paths.size() == 1) {
+                uniquelyRoutableNames.add(name);
+            }
+        });
     }
 
     @Override
@@ -117,11 +155,12 @@ final class XMLContentModelDisambiguatingDeserializer extends DelegatingDeserial
 
         RoutingResult routing = XMLContentModelMatcher.route(contentModel, inputs);
 
-        if (routing.getStatus() == RoutingResult.Status.NO_MATCH) {
-            throw JsonMappingException.from(p, formatNoMatchError(inputs));
-        }
-        if (routing.getStatus() == RoutingResult.Status.AMBIGUOUS) {
-            throw JsonMappingException.from(p, formatAmbiguousError(inputs, routing));
+        if (routing.getStatus() != RoutingResult.Status.SUCCESS) {
+            // Lenient handling: rather than failing the whole document on a content-model mismatch
+            // (which would violate the "be lenient, skip what you cannot place" philosophy and the
+            // disabled FAIL_ON_UNKNOWN_PROPERTIES), recover what we can. Elements we cannot route
+            // are skipped; with FAIL_ON_UNKNOWN_PROPERTIES disabled the delegate ignores them.
+            routing = lenientRoute(inputs);
         }
 
         Map<Integer, List<String>> routesByIndex = routing.getPathByIndex();
@@ -167,6 +206,81 @@ final class XMLContentModelDisambiguatingDeserializer extends DelegatingDeserial
             result = applyVirtualAssignments(result, nestedAssignments, ctxt);
         }
         return result;
+    }
+
+    /**
+     * Best-effort routing used when strict, ordered matching fails. The strategy, in order:
+     * <ol>
+     *   <li>the elements may merely be out of schema order, so stably reorder them into canonical
+     *       content-model order and re-match (this reuses the matcher's occurrence handling);</li>
+     *   <li>otherwise drop elements whose name cannot be uniquely routed and re-match the rest;</li>
+     *   <li>otherwise skip all content-model routing.</li>
+     * </ol>
+     * Any element not present in the returned routing is left in the token stream and ignored by the
+     * delegate (FAIL_ON_UNKNOWN_PROPERTIES is disabled). Every recovery path emits a WARN.
+     */
+    private RoutingResult lenientRoute(List<RoutingInput> inputs) {
+        // Attempt 1: treat as a pure ordering problem.
+        RoutingResult reordered = routeReordered(inputs, inputs);
+        if (reordered != null) {
+            LOGGER.warn("XML content for {} was not in schema order; elements were reordered to deserialize. "
+                    + "XML child sequence: {}", beanClass.getName(), xmlSequence(inputs));
+            return reordered;
+        }
+        // Attempt 2: keep only uniquely-routable elements, skip the rest.
+        List<RoutingInput> keep = new ArrayList<>();
+        List<RoutingInput> dropped = new ArrayList<>();
+        for (RoutingInput input : inputs) {
+            if (uniquelyRoutableNames.contains(input.getXmlName())) {
+                keep.add(input);
+            } else {
+                dropped.add(input);
+            }
+        }
+        if (!dropped.isEmpty() && !keep.isEmpty()) {
+            RoutingResult partial = routeReordered(keep, inputs);
+            if (partial != null) {
+                LOGGER.warn("Skipped {} XML element(s) of {} that could not be routed by the content model: {}",
+                        dropped.size(), beanClass.getName(), xmlSequence(dropped));
+                return partial;
+            }
+        }
+        // Attempt 3: give up on content-model routing entirely.
+        LOGGER.warn("{} Skipping content-model routing; un-routable elements will be ignored.",
+                formatNoMatchError(inputs));
+        return RoutingResult.success(new LinkedHashMap<>(), new LinkedHashMap<>());
+    }
+
+    /**
+     * Stably reorder {@code subset} into canonical content-model order, run the strict matcher, and
+     * if it succeeds remap the routing back to indices in {@code originalInputs}. Returns
+     * {@code null} when the reordered subset still does not match uniquely.
+     */
+    private RoutingResult routeReordered(List<RoutingInput> subset, List<RoutingInput> originalInputs) {
+        List<RoutingInput> sorted = new ArrayList<>(subset);
+        // List.sort is stable, so elements sharing an XML name keep their original relative order
+        // (preserving e.g. the order of repeated choice entries).
+        sorted.sort(Comparator.comparingInt(
+                input -> canonicalPosition.getOrDefault(input.getXmlName(), Integer.MAX_VALUE)));
+
+        RoutingResult result = XMLContentModelMatcher.route(contentModel, sorted);
+        if (result.getStatus() != RoutingResult.Status.SUCCESS) {
+            return null;
+        }
+
+        IdentityHashMap<RoutingInput, Integer> originalIndex = new IdentityHashMap<>();
+        for (int i = 0; i < originalInputs.size(); i++) {
+            originalIndex.put(originalInputs.get(i), i);
+        }
+        Map<Integer, List<String>> pathByIndex = new LinkedHashMap<>();
+        Map<Integer, OccurrenceKey> occurrenceByIndex = new LinkedHashMap<>();
+        for (Map.Entry<Integer, List<String>> entry : result.getPathByIndex().entrySet()) {
+            RoutingInput input = sorted.get(entry.getKey());
+            int original = originalIndex.get(input);
+            pathByIndex.put(original, entry.getValue());
+            occurrenceByIndex.put(original, result.getOccurrenceByIndex().get(entry.getKey()));
+        }
+        return RoutingResult.success(pathByIndex, occurrenceByIndex);
     }
 
     private Object applyVirtualAssignments(Object result,
@@ -236,35 +350,11 @@ final class XMLContentModelDisambiguatingDeserializer extends DelegatingDeserial
         return sb.toString();
     }
 
-    private String formatAmbiguousError(List<RoutingInput> inputs, RoutingResult routing) {
-        StringBuilder sb = new StringBuilder();
-        sb.append("Ambiguous XML content for ").append(beanClass.getName()).append(".\n");
-        sb.append("XML child sequence: ").append(xmlSequence(inputs)).append("\n");
-        sb.append("Remaining candidate paths:");
-        for (List<List<String>> candidate : routing.getCandidatePaths()) {
-            sb.append("\n- ");
-            for (int i = 0; i < candidate.size(); i++) {
-                if (i > 0) sb.append(", ");
-                sb.append(joinPath(candidate.get(i)));
-            }
-        }
-        return sb.toString();
-    }
-
     private static String xmlSequence(List<RoutingInput> inputs) {
         StringBuilder sb = new StringBuilder();
         for (int i = 0; i < inputs.size(); i++) {
             if (i > 0) sb.append(", ");
             sb.append(inputs.get(i).getXmlName());
-        }
-        return sb.toString();
-    }
-
-    private static String joinPath(List<String> path) {
-        StringBuilder sb = new StringBuilder();
-        for (int i = 0; i < path.size(); i++) {
-            if (i > 0) sb.append(".");
-            sb.append(path.get(i));
         }
         return sb.toString();
     }

--- a/common/src/main/java/com/regnosys/rosetta/common/serialisation/xml/serialization/RosettaBeanSerializer.java
+++ b/common/src/main/java/com/regnosys/rosetta/common/serialisation/xml/serialization/RosettaBeanSerializer.java
@@ -36,7 +36,14 @@ import com.regnosys.rosetta.common.serialisation.xml.VirtualXMLAttribute;
 
 import javax.xml.namespace.QName;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.BitSet;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 /**
@@ -56,24 +63,37 @@ public class RosettaBeanSerializer extends XmlBeanSerializer {
 
     private final SubstitutionMap _substitutionMap;
 
+    // When present, child elements are serialised in the order dictated by the XSD content model
+    // (computed per object against the present data), rather than the default property order.
+    private final XMLContentModelOrderer _contentModelOrderer;
+
     public RosettaBeanSerializer(XmlBeanSerializer src, SubstitutionMap substitutionMap) {
+        this(src, substitutionMap, null);
+    }
+
+    public RosettaBeanSerializer(XmlBeanSerializer src, SubstitutionMap substitutionMap,
+                                 XMLContentModelOrderer contentModelOrderer) {
         super(src);
         this._substitutionMap = substitutionMap;
+        this._contentModelOrderer = contentModelOrderer;
     }
 
     public RosettaBeanSerializer(RosettaBeanSerializer src, ObjectIdWriter objectIdWriter, Object filterId) {
         super(src, objectIdWriter, filterId);
         this._substitutionMap = src._substitutionMap;
+        this._contentModelOrderer = src._contentModelOrderer;
     }
 
     public RosettaBeanSerializer(RosettaBeanSerializer src, Set<String> toIgnore, Set<String> toInclude) {
         super(src, toIgnore, toInclude);
         this._substitutionMap = src._substitutionMap;
+        this._contentModelOrderer = src._contentModelOrderer;
     }
 
     protected RosettaBeanSerializer(RosettaBeanSerializer src, BeanPropertyWriter[] properties, BeanPropertyWriter[] filteredProperties) {
         super(src, properties, filteredProperties);
         this._substitutionMap = src._substitutionMap;
+        this._contentModelOrderer = src._contentModelOrderer;
     }
 
     @Override
@@ -128,6 +148,17 @@ public class RosettaBeanSerializer extends XmlBeanSerializer {
         g.writeEndObject();
     }
 
+    // For non-root beans the base XmlBeanSerializer.serialize() delegates here; reorder child
+    // elements to follow the XSD content model when an orderer is configured.
+    @Override
+    protected void serializeFields(Object bean, JsonGenerator gen, SerializerProvider provider) throws IOException {
+        if (_contentModelOrderer != null && gen instanceof ToXmlGenerator) {
+            serializeFieldsAndAddSchemaLocation(bean, (ToXmlGenerator) gen, provider);
+        } else {
+            super.serializeFields(bean, gen, provider);
+        }
+    }
+
     // Serialize fields as usual, but add the `schemaLocation` attribute at the end of all XML attributes.
     protected void serializeFieldsAndAddSchemaLocation(Object bean, ToXmlGenerator xgen, SerializerProvider provider)
             throws IOException {
@@ -145,11 +176,16 @@ public class RosettaBeanSerializer extends XmlBeanSerializer {
         int i = 0;
         final BitSet cdata = _cdata;
 
+        // Permutation of property indices that realises the content-model order. Identity when no
+        // orderer is configured or when the order cannot be improved/derived (safe fallback).
+        final int[] order = computeContentModelOrder(bean, props, textIndex);
+
         try {
             if (props.length == 0) {
                 writeSchemaLocation(xgen, provider);
             }
             for (final int len = props.length; i < len; ++i) {
+                final int pi = order[i];
                 // 28-jan-2014, pascal: we don't want to reset the attribute flag if we are an unwrapping serializer
                 // that started with nextIsAttribute to true because all properties should be unwrapped as attributes too.
                 if (i == attrCount && !isUnwrappingSerializer()) {
@@ -160,10 +196,10 @@ public class RosettaBeanSerializer extends XmlBeanSerializer {
                 if (i == textIndex) {
                     xgen.setNextIsUnwrapped(true);
                 }
-                xgen.setNextName(xmlNames[i]);
-                BeanPropertyWriter prop = props[i];
+                xgen.setNextName(xmlNames[pi]);
+                BeanPropertyWriter prop = props[pi];
                 if (prop != null) { // can have nulls in filtered list
-                    if ((cdata != null) && cdata.get(i)) {
+                    if ((cdata != null) && cdata.get(pi)) {
                         xgen.setNextIsCData(true);
                         prop.serializeAsField(bean, xgen, provider);
                         xgen.setNextIsCData(false);
@@ -184,14 +220,90 @@ public class RosettaBeanSerializer extends XmlBeanSerializer {
                 _anyGetterWriter.getAndSerialize(bean, xgen, provider);
             }
         } catch (Exception e) {
-            String name = (i == props.length) ? "[anySetter]" : props[i].getName();
+            String name = (i == props.length) ? "[anySetter]" : props[order[i]].getName();
             wrapAndThrow(provider, e, bean, name);
         } catch (StackOverflowError e) { // Bit tricky, can't do more calls as stack is full; so:
             JsonMappingException mapE = JsonMappingException.from(xgen,
                     "Infinite recursion (StackOverflowError)");
-            String name = (i == props.length) ? "[anySetter]" : props[i].getName();
+            String name = (i == props.length) ? "[anySetter]" : props[order[i]].getName();
             mapE.prependPath(new JsonMappingException.Reference(bean, name));
             throw mapE;
+        }
+    }
+
+    /**
+     * Computes a permutation of property indices that emits the content-model properties in the
+     * order required by the XSD content model, leaving every other property (and all attributes) in
+     * place. Only the slots occupied by <em>present</em> content-model properties are permuted among
+     * themselves, so absent properties and non-content-model properties never move. Returns the
+     * identity permutation when no orderer is set, when a text/unwrapped property is present (where
+     * reordering is unsafe), or when the present set cannot be ordered.
+     */
+    private int[] computeContentModelOrder(Object bean, BeanPropertyWriter[] props, int textIndex) {
+        final int len = props.length;
+        final int[] order = new int[len];
+        for (int i = 0; i < len; i++) {
+            order[i] = i;
+        }
+        if (_contentModelOrderer == null || textIndex >= 0) {
+            return order;
+        }
+        final Set<String> contentModelProperties = _contentModelOrderer.getContentModelProperties();
+        final List<Integer> presentSlots = new ArrayList<>();
+        final Map<String, Integer> presentNameToIndex = new LinkedHashMap<>();
+        final Set<String> present = new LinkedHashSet<>();
+        for (int i = _attributeCount; i < len; i++) {
+            final BeanPropertyWriter prop = props[i];
+            if (prop == null) {
+                continue;
+            }
+            final String name = prop.getName();
+            if (!contentModelProperties.contains(name) || !isPresent(prop, bean)) {
+                continue;
+            }
+            presentSlots.add(i);
+            presentNameToIndex.put(name, i);
+            present.add(name);
+        }
+        if (presentSlots.size() <= 1) {
+            return order;
+        }
+        final List<String> ordered = _contentModelOrderer.order(present);
+        if (ordered == null || ordered.size() != presentSlots.size()) {
+            return order; // fallback: keep default order
+        }
+        Collections.sort(presentSlots);
+        for (int k = 0; k < presentSlots.size(); k++) {
+            final Integer target = presentNameToIndex.get(ordered.get(k));
+            if (target == null) {
+                return identity(len); // inconsistent; bail safely
+            }
+            order[presentSlots.get(k)] = target;
+        }
+        return order;
+    }
+
+    private static int[] identity(int len) {
+        int[] order = new int[len];
+        for (int i = 0; i < len; i++) {
+            order[i] = i;
+        }
+        return order;
+    }
+
+    private static boolean isPresent(BeanPropertyWriter prop, Object bean) {
+        try {
+            final Object value = prop.get(bean);
+            if (value == null) {
+                return false;
+            }
+            if (value instanceof Collection) {
+                return !((Collection<?>) value).isEmpty();
+            }
+            return true;
+        } catch (Exception e) {
+            // If we cannot read the value, assume present so it keeps its slot.
+            return true;
         }
     }
 

--- a/common/src/main/java/com/regnosys/rosetta/common/serialisation/xml/serialization/RosettaBeanSerializerModifier.java
+++ b/common/src/main/java/com/regnosys/rosetta/common/serialisation/xml/serialization/RosettaBeanSerializerModifier.java
@@ -25,21 +25,31 @@ import com.fasterxml.jackson.databind.introspect.AnnotatedMember;
 import com.fasterxml.jackson.databind.ser.BeanPropertyWriter;
 import com.fasterxml.jackson.databind.ser.BeanSerializerModifier;
 import com.fasterxml.jackson.dataformat.xml.ser.XmlBeanSerializer;
+import com.regnosys.rosetta.common.serialisation.xml.RosettaXMLTypeConfigLookup;
 import com.regnosys.rosetta.common.serialisation.xml.SubstitutionMap;
 import com.regnosys.rosetta.common.serialisation.xml.SubstitutionMapLoader;
+import com.regnosys.rosetta.common.serialisation.xml.config.RosettaXMLConfiguration;
+import com.regnosys.rosetta.common.serialisation.xml.config.TypeXMLConfiguration;
+import com.regnosys.rosetta.common.serialisation.xml.config.XMLContentModel;
 
 import java.util.List;
+import java.util.Optional;
 
 /**
  * Support for serialising substitution groups by replacing property writers
  * with {@code SubstitutingBeanPropertyWriter}, which will serialise the right
- * property name based on the type of the value.
+ * property name based on the type of the value. Also installs an
+ * {@link XMLContentModelOrderer} on the {@link RosettaBeanSerializer} for types whose XML
+ * configuration provides a {@code contentModel}, so that child elements are emitted in XSD order.
  */
 public class RosettaBeanSerializerModifier extends BeanSerializerModifier {
     private final SubstitutionMapLoader substitutionMapLoader;
+    private final RosettaXMLConfiguration rosettaXMLConfiguration;
 
-    public RosettaBeanSerializerModifier(SubstitutionMapLoader substitutionMapLoader) {
+    public RosettaBeanSerializerModifier(SubstitutionMapLoader substitutionMapLoader,
+                                         RosettaXMLConfiguration rosettaXMLConfiguration) {
         this.substitutionMapLoader = substitutionMapLoader;
+        this.rosettaXMLConfiguration = rosettaXMLConfiguration;
     }
 
     @Override
@@ -65,8 +75,17 @@ public class RosettaBeanSerializerModifier extends BeanSerializerModifier {
         if (!(serializer instanceof XmlBeanSerializer)) {
             return serializer;
         }
-        final AnnotationIntrospector intr = config.getAnnotationIntrospector();
 
-        return new RosettaBeanSerializer((XmlBeanSerializer) serializer, null);
+        XMLContentModelOrderer contentModelOrderer = null;
+        Optional<TypeXMLConfiguration> typeConfig =
+                RosettaXMLTypeConfigLookup.getTypeXMLConfiguration(rosettaXMLConfiguration, config, beanDesc);
+        if (typeConfig.isPresent()) {
+            Optional<XMLContentModel> contentModel = typeConfig.get().getContentModel();
+            if (contentModel.isPresent()) {
+                contentModelOrderer = new XMLContentModelOrderer(contentModel.get());
+            }
+        }
+
+        return new RosettaBeanSerializer((XmlBeanSerializer) serializer, null, contentModelOrderer);
     }
 }

--- a/common/src/main/java/com/regnosys/rosetta/common/serialisation/xml/serialization/XMLContentModelOrderer.java
+++ b/common/src/main/java/com/regnosys/rosetta/common/serialisation/xml/serialization/XMLContentModelOrderer.java
@@ -1,0 +1,234 @@
+package com.regnosys.rosetta.common.serialisation.xml.serialization;
+
+/*-
+ * ==============
+ * Rune Common
+ * ==============
+ * Copyright (C) 2018 - 2026 REGnosys
+ * ==============
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ==============
+ */
+
+import com.regnosys.rosetta.common.serialisation.xml.config.XMLContentModel;
+import com.regnosys.rosetta.common.serialisation.xml.config.XMLContentModelNodeType;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Computes the order in which a Rosetta type's child elements should be serialised so that the
+ * resulting XML follows the configured XSD content model. This is the serialisation-time dual of
+ * {@link com.regnosys.rosetta.common.serialisation.xml.deserialization.XMLContentModelMatcher}:
+ * the matcher routes an <em>ordered</em> input against the content model, whereas this orderer
+ * takes the <em>set of present properties</em> and produces a valid ordering against the same model.
+ *
+ * <p>Ordering is computed at the granularity of Rosetta properties (the first segment of each
+ * content-model element path). This is sound because every property maps to a single contiguous
+ * block of XML elements: a direct element is one block, and a {@code VIRTUAL} group's leaves are a
+ * contiguous subtree of the content model. Working at property granularity lets the orderer pick a
+ * data-dependent branch order (e.g. {@code x,a,b} vs {@code y,b,a}) that a static property
+ * reordering could never express.</p>
+ *
+ * <p>When the present set cannot be fully consumed by the model (an unexpected combination, or a
+ * model shape the orderer does not handle), {@link #order(Set)} returns {@code null} and the caller
+ * falls back to the default serialisation order. The change is therefore never worse than today.</p>
+ */
+final class XMLContentModelOrderer {
+
+    /** Safety bound on the search to avoid pathological blow-ups; falls back to default order. */
+    private static final int MAX_CANDIDATES = 256;
+
+    private final Node root;
+    private final Set<String> contentModelProperties;
+
+    XMLContentModelOrderer(XMLContentModel contentModel) {
+        this.contentModelProperties = Collections.unmodifiableSet(leafProperties(contentModel, new LinkedHashSet<>()));
+        this.root = reduce(contentModel);
+    }
+
+    /**
+     * @return the set of Rosetta property names that participate in this content model (the first
+     *         path segment of each element). Only these properties are reordered; all others keep
+     *         their position.
+     */
+    Set<String> getContentModelProperties() {
+        return contentModelProperties;
+    }
+
+    /**
+     * Compute a valid serialisation order for the supplied present properties.
+     *
+     * @param presentProperties the content-model properties that actually have a value on the bean.
+     * @return an ordering consuming exactly {@code presentProperties}, or {@code null} if no such
+     *         ordering could be derived (caller should keep the default order).
+     */
+    List<String> order(Set<String> presentProperties) {
+        if (presentProperties.isEmpty()) {
+            return Collections.emptyList();
+        }
+        if (root == null) {
+            return null;
+        }
+        List<List<String>> candidates = new ArrayList<>();
+        enumerate(root, presentProperties, candidates);
+        for (List<String> candidate : candidates) {
+            if (candidate.size() == presentProperties.size()
+                    && new LinkedHashSet<>(candidate).equals(presentProperties)) {
+                return candidate;
+            }
+        }
+        return null;
+    }
+
+    // -------------------------------------------------------------------------
+    // Reduction: collapse each single-property subtree into one PROP node.
+    // -------------------------------------------------------------------------
+
+    private static Node reduce(XMLContentModel model) {
+        Set<String> props = leafProperties(model, new LinkedHashSet<>());
+        boolean required = model.minOccursOrDefault() >= 1;
+        if (props.size() <= 1) {
+            if (props.isEmpty()) {
+                return null; // contributes no element (e.g. ANY without a routing path)
+            }
+            return new Node(props.iterator().next(), required);
+        }
+        List<Node> children = new ArrayList<>();
+        model.getChildren().ifPresent(cs -> {
+            for (XMLContentModel c : cs) {
+                Node reduced = reduce(c);
+                if (reduced != null) {
+                    children.add(reduced);
+                }
+            }
+        });
+        return new Node(model.getNodeType(), children, required);
+    }
+
+    private static Set<String> leafProperties(XMLContentModel node, Set<String> acc) {
+        XMLContentModelNodeType type = node.getNodeType();
+        if (type == XMLContentModelNodeType.ELEMENT || type == XMLContentModelNodeType.ANY) {
+            node.getPath().filter(p -> !p.isEmpty()).ifPresent(p -> acc.add(p.get(0)));
+        }
+        node.getChildren().ifPresent(cs -> {
+            for (XMLContentModel c : cs) {
+                leafProperties(c, acc);
+            }
+        });
+        return acc;
+    }
+
+    // -------------------------------------------------------------------------
+    // Enumeration of valid property orderings.
+    // -------------------------------------------------------------------------
+
+    private void enumerate(Node node, Set<String> present, List<List<String>> out) {
+        if (node.property != null) {
+            if (present.contains(node.property)) {
+                out.add(new ArrayList<>(Collections.singletonList(node.property)));
+            } else if (!node.required) {
+                out.add(new ArrayList<>());
+            }
+            // required but absent -> no result (this branch cannot be satisfied)
+            return;
+        }
+        switch (node.nodeType) {
+            case CHOICE:
+                enumerateChoice(node, present, out);
+                break;
+            case SEQUENCE:
+            case ALL:
+            default:
+                enumerateSequence(node, present, out);
+                break;
+        }
+    }
+
+    private void enumerateChoice(Node node, Set<String> present, List<List<String>> out) {
+        for (Node child : node.children) {
+            enumerate(child, present, out);
+            if (out.size() > MAX_CANDIDATES) {
+                return;
+            }
+        }
+        if (out.isEmpty() && !node.required) {
+            out.add(new ArrayList<>());
+        }
+    }
+
+    private void enumerateSequence(Node node, Set<String> present, List<List<String>> out) {
+        List<List<String>> acc = new ArrayList<>();
+        acc.add(new ArrayList<>());
+        for (Node child : node.children) {
+            List<List<String>> childOptions = new ArrayList<>();
+            enumerate(child, present, childOptions);
+            if (childOptions.isEmpty()) {
+                return; // a required child could not be satisfied -> whole sequence fails
+            }
+            List<List<String>> next = new ArrayList<>();
+            for (List<String> prefix : acc) {
+                for (List<String> suffix : childOptions) {
+                    if (disjoint(prefix, suffix)) {
+                        List<String> combined = new ArrayList<>(prefix);
+                        combined.addAll(suffix);
+                        next.add(combined);
+                        if (next.size() > MAX_CANDIDATES) {
+                            out.addAll(next);
+                            return;
+                        }
+                    }
+                }
+            }
+            acc = next;
+        }
+        out.addAll(acc);
+    }
+
+    private static boolean disjoint(List<String> a, List<String> b) {
+        for (String s : b) {
+            if (a.contains(s)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * A reduced content-model node: either a single property ({@link #property} != null) or a
+     * compound group with a {@link #nodeType} and {@link #children}.
+     */
+    private static final class Node {
+        final String property;
+        final XMLContentModelNodeType nodeType;
+        final List<Node> children;
+        final boolean required;
+
+        Node(String property, boolean required) {
+            this.property = property;
+            this.nodeType = null;
+            this.children = Collections.emptyList();
+            this.required = required;
+        }
+
+        Node(XMLContentModelNodeType nodeType, List<Node> children, boolean required) {
+            this.property = null;
+            this.nodeType = nodeType;
+            this.children = children;
+            this.required = required;
+        }
+    }
+}

--- a/common/src/test/java/com/regnosys/rosetta/common/serialisation/xml/XmlContentModelDisambiguationTest.java
+++ b/common/src/test/java/com/regnosys/rosetta/common/serialisation/xml/XmlContentModelDisambiguationTest.java
@@ -20,7 +20,6 @@ package com.regnosys.rosetta.common.serialisation.xml;
  * ==============
  */
 
-import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.io.Resources;
 import com.regnosys.rosetta.common.serialisation.RosettaObjectMapperCreator;
@@ -48,7 +47,6 @@ import java.util.Optional;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -251,15 +249,18 @@ public class XmlContentModelDisambiguationTest {
     // -------------- Failure cases --------------
 
     @Test
-    public void testFxMissingRequiredLinearPayoffRegionFails() {
+    public void testFxMissingRequiredLinearPayoffRegionIsLenient() throws IOException {
+        // Previously a hard failure. The deserializer is now lenient: rather than rejecting the
+        // whole document it keeps the elements it can place (by name) and skips the rest.
         String xml = "<FpmlFxTargetKnockoutForward>"
                 + "<constantPayoffRegion id=\"base-constant\"/>"
                 + "</FpmlFxTargetKnockoutForward>";
 
-        JsonMappingException ex = assertThrows(JsonMappingException.class,
-                () -> xmlMapper.readValue(xml, FpmlFxTargetKnockoutForward.class));
-        assertTrue(ex.getMessage().contains("FpmlFxTargetKnockoutForward"),
-                "Expected target type name in message: " + ex.getMessage());
+        FpmlFxTargetKnockoutForward actual = xmlMapper.readValue(xml, FpmlFxTargetKnockoutForward.class);
+
+        assertNotNull(actual.getConstantPayoffRegion());
+        assertEquals(1, actual.getConstantPayoffRegion().size());
+        assertEquals("base-constant", actual.getConstantPayoffRegion().get(0).getId());
     }
 
     /**
@@ -286,17 +287,42 @@ public class XmlContentModelDisambiguationTest {
     }
 
     @Test
-    public void testTradeIdentifierAmbiguousFails() {
+    public void testTradeIdentifierAmbiguousIsLenient() throws IOException {
+        // Genuinely ambiguous against the content model (issuer belongs to one branch,
+        // partyReference to another). Previously a hard failure; the deserializer now skips the
+        // element it cannot uniquely route (tradeId is ambiguous) and keeps the rest by name.
         String xml = "<FpmlTradeIdentifier id=\"ti-ambiguous\">"
                 + "<issuer scheme=\"urn:issuer\">BANK-A</issuer>"
                 + "<partyReference href=\"party-1\"/>"
                 + "<tradeId scheme=\"urn:trade-id\">ABC-123</tradeId>"
                 + "</FpmlTradeIdentifier>";
 
-        JsonMappingException ex = assertThrows(JsonMappingException.class,
-                () -> xmlMapper.readValue(xml, FpmlTradeIdentifier.class));
-        assertTrue(ex.getMessage().contains("FpmlTradeIdentifier"),
-                "Expected target type name in message: " + ex.getMessage());
+        FpmlTradeIdentifier actual = xmlMapper.readValue(xml, FpmlTradeIdentifier.class);
+
+        assertEquals("ti-ambiguous", actual.getId());
+        assertEquals("BANK-A", actual.getIssuer().getValue());
+        assertNotNull(actual.getPartyReference());
+        assertEquals("party-1", actual.getPartyReference().getHref());
+        // No exception is thrown; the document is deserialised best-effort.
+    }
+
+    @Test
+    public void testMisorderedInputIsReorderedAndDeserialised() throws IOException {
+        // Safety net: an XML document whose elements are valid but out of schema order
+        // (versionedTradeId before partyReference) must still deserialise, by being stably
+        // reordered into content-model order rather than rejected.
+        String xml = "<FpmlTradeIdentifier>"
+                + "<versionedTradeId scheme=\"urn:version\">V-1</versionedTradeId>"
+                + "<partyReference href=\"party-1\"/>"
+                + "</FpmlTradeIdentifier>";
+
+        FpmlTradeIdentifier actual = xmlMapper.readValue(xml, FpmlTradeIdentifier.class);
+
+        assertNotNull(actual.getPartyReference());
+        assertEquals("party-1", actual.getPartyReference().getHref());
+        assertNotNull(actual.getTradeIdentifierChoice());
+        assertEquals(1, actual.getTradeIdentifierChoice().size());
+        assertEquals("V-1", actual.getTradeIdentifierChoice().get(0).getVersionedTradeId().getValue());
     }
 
     // -------------- Config loading tests --------------

--- a/common/src/test/java/com/regnosys/rosetta/common/serialisation/xml/XmlContentModelSerializationOrderTest.java
+++ b/common/src/test/java/com/regnosys/rosetta/common/serialisation/xml/XmlContentModelSerializationOrderTest.java
@@ -1,0 +1,87 @@
+package com.regnosys.rosetta.common.serialisation.xml;
+
+/*-
+ * ==============
+ * Rune Common
+ * ==============
+ * Copyright (C) 2018 - 2026 REGnosys
+ * ==============
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * ==============
+ */
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.ObjectWriter;
+import com.google.common.io.Resources;
+import com.regnosys.rosetta.common.serialisation.RosettaObjectMapperCreator;
+import com.rosetta.test.FpmlReference;
+import com.rosetta.test.FpmlTextValue;
+import com.rosetta.test.FpmlTradeIdentifier;
+import com.rosetta.test.FpmlTradeIdentifierChoice;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+/**
+ * End-to-end round-trip test for content-model-ordered XML serialization.
+ *
+ * <p>The XSD content model for {@code FpmlTradeIdentifier} (branch 2) requires:
+ * {@code partyReference, accountReference?, (tradeId | versionedTradeId)+}, where the choice is
+ * carried by the VIRTUAL property {@code tradeIdentifierChoice}.</p>
+ *
+ * <p>The deserializer enforces this order via {@code XMLContentModelDisambiguatingDeserializer}.
+ * Without content-model-aware serialization the serializer emits child elements in bean-property
+ * order: the VIRTUAL {@code tradeIdentifierChoice} is unwrapped to the FRONT, producing
+ * {@code versionedTradeId, partyReference} — the wrong (non-XSD) order whose re-deserialisation
+ * fails. This test asserts the serializer now follows the content model and the output round-trips.</p>
+ */
+public class XmlContentModelSerializationOrderTest {
+
+    private final ObjectMapper xmlMapper;
+
+    public XmlContentModelSerializationOrderTest() throws IOException {
+        try (InputStream inputStream = Resources.getResource(
+                "serialisation/xml/xml-config/content-model-xml-config.json").openStream()) {
+            xmlMapper = RosettaObjectMapperCreator.forXML(inputStream).create();
+        }
+    }
+
+    @Test
+    public void serializerEmitsContentModelOrderAndRoundTrips() throws IOException {
+        // A valid object: partyReference + a versionedTradeId carried by the virtual choice.
+        FpmlTradeIdentifier object = FpmlTradeIdentifier.builder()
+                .setPartyReference(FpmlReference.builder().setHref("party-1").build())
+                .addTradeIdentifierChoice(FpmlTradeIdentifierChoice.builder()
+                        .setVersionedTradeId(FpmlTextValue.builder().setValue("V-1").build())
+                        .build())
+                .build();
+
+        ObjectWriter writer = xmlMapper.writerWithDefaultPrettyPrinter();
+        String xml = writer.writeValueAsString(object);
+        System.out.println("=== SERIALISED ===\n" + xml);
+
+        int vtid = xml.indexOf("versionedTradeId");
+        int pref = xml.indexOf("partyReference");
+        assertTrue(vtid >= 0 && pref >= 0, "both elements should be present");
+
+        // The serializer follows the XSD content model, so partyReference is emitted BEFORE
+        // versionedTradeId.
+        assertTrue(pref < vtid,
+                "Expected partyReference before versionedTradeId (XSD order), got:\n" + xml);
+
+        // And the serializer's own output round-trips cleanly through the strict deserializer.
+        try {
+            FpmlTradeIdentifier roundTripped = xmlMapper.readValue(xml, FpmlTradeIdentifier.class);
+            assertEquals(object, roundTripped, "round-tripped object should equal the original");
+            System.out.println("Round-trip succeeded and matched the original object.");
+        } catch (Exception e) {
+            fail("Re-deserialisation of serializer output failed: " + e.getMessage());
+        }
+    }
+}

--- a/common/src/test/java/com/regnosys/rosetta/common/serialisation/xml/serialization/XMLContentModelOrdererTest.java
+++ b/common/src/test/java/com/regnosys/rosetta/common/serialisation/xml/serialization/XMLContentModelOrdererTest.java
@@ -1,0 +1,128 @@
+package com.regnosys.rosetta.common.serialisation.xml.serialization;
+
+/*-
+ * ==============
+ * Rune Common
+ * ==============
+ * Copyright (C) 2018 - 2026 REGnosys
+ * ==============
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * ==============
+ */
+
+import com.regnosys.rosetta.common.serialisation.xml.config.OccursMax;
+import com.regnosys.rosetta.common.serialisation.xml.config.XMLContentModel;
+import com.regnosys.rosetta.common.serialisation.xml.config.XMLContentModelNodeType;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class XMLContentModelOrdererTest {
+
+    // ---- helpers to build content models concisely ----
+
+    private static XMLContentModel element(String name, int min, OccursMax max) {
+        return new XMLContentModel(XMLContentModelNodeType.ELEMENT,
+                Optional.of(name), Optional.empty(),
+                Optional.of(Collections.singletonList(name)),
+                Optional.of(min), Optional.of(max), Optional.empty());
+    }
+
+    private static XMLContentModel nested(String prop, String name, int min, OccursMax max) {
+        return new XMLContentModel(XMLContentModelNodeType.ELEMENT,
+                Optional.of(name), Optional.empty(),
+                Optional.of(Arrays.asList(prop, name)),
+                Optional.of(min), Optional.of(max), Optional.empty());
+    }
+
+    private static XMLContentModel group(XMLContentModelNodeType type, int min, OccursMax max, XMLContentModel... children) {
+        return new XMLContentModel(type, Optional.empty(), Optional.empty(), Optional.empty(),
+                Optional.of(min), Optional.of(max), Optional.of(Arrays.asList(children)));
+    }
+
+    private static Set<String> set(String... s) {
+        return new LinkedHashSet<>(Arrays.asList(s));
+    }
+
+    // ---- data-dependent ordering: the case a static reorder cannot handle ----
+
+    @Test
+    void dataDependentOrderPicksBranchOrderFromPresentData() {
+        // CHOICE[ SEQ(x, a, b), SEQ(y, b, a) ]  -> order of a,b depends on x vs y
+        XMLContentModel model = group(XMLContentModelNodeType.CHOICE, 1, OccursMax.of(1),
+                group(XMLContentModelNodeType.SEQUENCE, 1, OccursMax.of(1),
+                        element("x", 1, OccursMax.of(1)),
+                        element("a", 1, OccursMax.of(1)),
+                        element("b", 1, OccursMax.of(1))),
+                group(XMLContentModelNodeType.SEQUENCE, 1, OccursMax.of(1),
+                        element("y", 1, OccursMax.of(1)),
+                        element("b", 1, OccursMax.of(1)),
+                        element("a", 1, OccursMax.of(1))));
+        XMLContentModelOrderer orderer = new XMLContentModelOrderer(model);
+
+        assertEquals(Arrays.asList("x", "a", "b"), orderer.order(set("x", "a", "b")));
+        assertEquals(Arrays.asList("y", "b", "a"), orderer.order(set("y", "a", "b")));
+    }
+
+    // ---- the FpML TradeIdentifier shape: partyReference before the virtual choice ----
+
+    @Test
+    void tradeIdentifierOrdersPartyReferenceBeforeVirtualChoice() {
+        // CHOICE[ SEQ(issuer, tradeId),
+        //         SEQ( SEQ(partyReference, accountReference?),
+        //              CHOICE*( tradeIdentifierChoice.tradeId | tradeIdentifierChoice.versionedTradeId ) ) ]
+        XMLContentModel model = group(XMLContentModelNodeType.CHOICE, 1, OccursMax.of(1),
+                group(XMLContentModelNodeType.SEQUENCE, 1, OccursMax.of(1),
+                        element("issuer", 1, OccursMax.of(1)),
+                        element("tradeId", 1, OccursMax.of(1))),
+                group(XMLContentModelNodeType.SEQUENCE, 1, OccursMax.of(1),
+                        group(XMLContentModelNodeType.SEQUENCE, 1, OccursMax.of(1),
+                                element("partyReference", 1, OccursMax.of(1)),
+                                element("accountReference", 0, OccursMax.of(1))),
+                        group(XMLContentModelNodeType.CHOICE, 0, OccursMax.unbounded(),
+                                nested("tradeIdentifierChoice", "tradeId", 1, OccursMax.of(1)),
+                                nested("tradeIdentifierChoice", "versionedTradeId", 1, OccursMax.of(1)))));
+        XMLContentModelOrderer orderer = new XMLContentModelOrderer(model);
+
+        assertEquals(set("issuer", "tradeId", "partyReference", "accountReference", "tradeIdentifierChoice"),
+                orderer.getContentModelProperties());
+        assertEquals(Arrays.asList("partyReference", "tradeIdentifierChoice"),
+                orderer.order(set("partyReference", "tradeIdentifierChoice")));
+        assertEquals(Arrays.asList("partyReference", "accountReference", "tradeIdentifierChoice"),
+                orderer.order(set("partyReference", "accountReference", "tradeIdentifierChoice")));
+        assertEquals(Arrays.asList("issuer", "tradeId"),
+                orderer.order(set("issuer", "tradeId")));
+    }
+
+    // ---- safe fallback when the present set cannot be consumed by the model ----
+
+    @Test
+    void returnsNullWhenPresentSetCannotBeOrdered() {
+        XMLContentModel model = group(XMLContentModelNodeType.SEQUENCE, 1, OccursMax.of(1),
+                element("a", 1, OccursMax.of(1)),
+                element("b", 1, OccursMax.of(1)));
+        XMLContentModelOrderer orderer = new XMLContentModelOrderer(model);
+
+        // "c" is not part of the model -> no full consumption -> null (caller keeps default order).
+        assertNull(orderer.order(set("a", "c")));
+    }
+
+    @Test
+    void emptyPresentSetYieldsEmptyOrder() {
+        XMLContentModel model = group(XMLContentModelNodeType.SEQUENCE, 1, OccursMax.of(1),
+                element("a", 0, OccursMax.of(1)));
+        XMLContentModelOrderer orderer = new XMLContentModelOrderer(model);
+
+        List<String> order = orderer.order(Collections.emptySet());
+        assertEquals(Collections.emptyList(), order);
+    }
+}


### PR DESCRIPTION
## Problem

Copying a sample (and any deserialise → re-serialise → validate flow) can fail with:

```
Cannot route XML content for ...PartyTradeIdentifier... XML child sequence: versionedTradeId, partyReference
```

The XML **serialiser** emitted child elements in bean-property order, while the disambiguating **deserialiser** enforces XSD content-model order. When the two diverge — e.g. the `VIRTUAL` `tradeIdentifierChoice` is unwrapped ahead of `partyReference` — the serialiser produces XSD-invalid XML (`versionedTradeId` before `partyReference`) which then fails to deserialise. Only the re-serialise-then-validate path exercises this, which is why normal ingest and the round-trip tests (whose re-deserialise / XSD-validate assertions are commented out) never caught it.

## Fix

**Serialisation — emit in content-model order.** New `XMLContentModelOrderer` is the serialisation-time dual of `XMLContentModelMatcher`: given the set of *present* properties it walks the content model (collapsing `VIRTUAL` groups, backtracking over choices) and returns a valid order — including data-dependent branch orders (`x,a,b` vs `y,b,a`) that a static reorder cannot express. `RosettaBeanSerializer` permutes only the slots of present content-model properties; attributes, absent and non-content-model properties keep their position. Falls back to the default order whenever no order can be derived, so it is never worse than before.

**Deserialisation — be lenient instead of throwing.** `XMLContentModelDisambiguatingDeserializer` no longer fails the whole document on a mismatch. It (1) stably reorders misordered input into content-model order and re-matches, (2) else drops only elements that cannot be uniquely routed, (3) else skips content-model routing entirely. Un-routed elements are ignored by the delegate (`FAIL_ON_UNKNOWN_PROPERTIES` is disabled). Every recovery path logs a `WARN`. This unblocks already-stored / third-party misordered XML.

## Tests

- `XMLContentModelOrdererTest` — unit-tests the orderer, incl. the data-dependent `x,a,b / y,b,a` case and safe fallback.
- `XmlContentModelSerializationOrderTest` — end-to-end serialise→deserialise round-trip; asserts `partyReference` is now emitted before `versionedTradeId` and the output round-trips.
- `XmlContentModelDisambiguationTest` — the two former hard-failure cases now assert lenient best-effort deserialisation; new `testMisorderedInputIsReorderedAndDeserialised` covers the safety net.

Full `common` module suite: 231 tests pass, 0 checkstyle violations.